### PR TITLE
NativeWindow doesn't provide OnHandleChange

### DIFF
--- a/WinApi/Windows/NativeWindow.cs
+++ b/WinApi/Windows/NativeWindow.cs
@@ -18,7 +18,26 @@ namespace WinApi.Windows
     /// </summary>
     public class NativeWindow : INativeAttachable
     {
-        public IntPtr Handle { get; protected set; }
+        IntPtr handle;
+
+        public IntPtr Handle
+        {
+            get
+            {
+                return handle;
+            }
+
+            protected set
+            {
+                handle = value;
+                OnHandleChange();
+            }
+        }
+
+        /// <summary>
+        /// This method is invoked when the value of the Handle property has changed.
+        /// </summary>
+        protected virtual void OnHandleChange() { }
 
         void INativeAttachable.Attach(IntPtr handle)
         {


### PR DESCRIPTION
For some lightweight applications, such as sniffing WM_DEVICECHANGE (and subsequent DBT_DEVICEARRIVAL events), we must call RegisterDeviceNotification() when we have a valid handle; but we must also re-register if our handle ever changes. In the Windows.Forms NativeWindow implementation, this is done in the OnHandleChanged() method. This PR adds such a method to WinApi.