### PR TITLE
Add SetLastError()

### DIFF
--- a/WinApi/Kernel32/Methods.cs
+++ b/WinApi/Kernel32/Methods.cs
@@ -13,6 +13,9 @@ namespace WinApi.Kernel32
         public static extern uint GetLastError();
 
         [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern void SetLastError(uint dwErrCode);
+
+        [DllImport(LibraryName, ExactSpelling = true)]
         public static extern bool DisableThreadLibraryCalls(IntPtr hModule);
 
         [DllImport(LibraryName, ExactSpelling = true)]


### PR DESCRIPTION
With some winapi functions, it's ambiguous whether the call succeeded from the return value (e.g. `IsWindowVisible`, `GetWindowLongPtrW`, etc.). The only way to know for sure is to set the thread's error code to zero before the call and check it after.