### PR TITLE
Add Publish to Nuget Github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,75 @@
+name: Publish to Nuget
+on:
+  push:
+    branches:
+      - master # Default release branch
+jobs:
+  publish:
+    name: Build, pack & publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish on version change (WinApi.Desktop)
+        id: publish_nuget_WinApi-Desktop
+        uses: Rebel028/publish-nuget@v2.6.3
+        with:
+          # Filepath of the project to be packaged, relative to root of repository
+          PROJECT_FILE_PATH: WinApi.Desktop/WinApi.Desktop.csproj
+          
+          # NuGet package id, used for version detection & defaults to project name
+          # PACKAGE_NAME: Core
+          
+          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
+          # VERSION_FILE_PATH: Directory.Build.props
+
+          # Regex pattern to extract version info in a capturing group
+          # VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
+          
+          # Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
+          # VERSION_STATIC: 1.0.0
+
+          # Flag to toggle git tagging, enabled by default
+          # TAG_COMMIT: true
+
+          # Format of the git tag, [*] gets replaced with actual version
+          # TAG_FORMAT: v*
+
+          # API key to authenticate with NuGet server, or a token, issued for GITHUB_USER if you use GPR
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+
+          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
+          # NUGET_SOURCE: https://api.nuget.org
+
+          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
+          # INCLUDE_SYMBOLS: false
+          
+          # Flag to throw an error when trying to publish an existing version of a package
+          # THOW_ERROR_IF_VERSION_EXISTS: false
+
+      - name: Publish on version change (WinApi.DxUtils)
+        id: publish_nuget_WinApi-DxUtils
+        uses: Rebel028/publish-nuget@v2.6.3
+        with:
+          PROJECT_FILE_PATH: WinApi.DxUtils/WinApi.DxUtils.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          
+      - name: Publish on version change (WinApi.Utils)
+        id: publish_nuget_WinApi-Utils
+        uses: Rebel028/publish-nuget@v2.6.3
+        with:
+          PROJECT_FILE_PATH: WinApi.Utils/WinApi.Utils.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          
+      - name: Publish on version change (WinApi.Windows.Controls)
+        id: publish_nuget_WinApi_Windows-Controls
+        uses: Rebel028/publish-nuget@v2.6.3
+        with:
+          PROJECT_FILE_PATH: WinApi.Windows.Controls/WinApi.Windows.Controls.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          
+      - name: Publish on version change (WinApi)
+        id: publish_nuget_WinApi
+        uses: Rebel028/publish-nuget@v2.6.3
+        with:
+          PROJECT_FILE_PATH: WinApi/WinApi.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}


### PR DESCRIPTION
This adds a Github action to publish the projects on Nuget. It runs on every push to the `master` branch, and for each project it checks whether the version in the `csproj` file is greater than the version on Nuget. If it is, it builds the project and uploads to Nuget.

Note: the Nuget API key must be added as a repository secret under the name `NUGET_API_KEY`.