### PR TITLE
Add debug functions (debugapi.h)

### DIFF
--- a/WinApi/Kernel32/Methods.cs
+++ b/WinApi/Kernel32/Methods.cs
@@ -188,9 +188,31 @@ namespace WinApi.Kernel32
 
         [DllImport(LibraryName, ExactSpelling = true)]
         public static extern uint GetCurrentProcessorNumber();
-
+        
         #endregion
 
+        #region Debug Functions
+            
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern bool DebugBreakProcess(IntPtr Process);
+        
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern void DebugBreak();
+        
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern bool DebugActiveProcess(uint dwProcessId);    
+        
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern bool DebugActiveProcessStop(uint dwProcessId);        
+        
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern bool CheckRemoteDebuggerPresent(IntPtr hProcess, out int pbDebuggerPresent); 
+            
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern bool ContinueDebugEvent(uint dwProcessId, uint dwThreadId, uint dwContinueStatus);         
+         
+        #endregion
+        
         #region File Management Functions
 
         [DllImport(LibraryName, CharSet = Properties.BuildCharSet)]


### PR DESCRIPTION
- Debug Functions region
- DebugBreakProcess
- DebugBreak
- DebugActiveProcess
- DebugActiveProcessStop
- CheckRemoteDebuggerPresent
- ContinueDebugEvent

Added +6 native debug functions from **_debugapi.h_** added them in a region in **_WinApi/WinApi/Kernel32/Methods.cs_**

_This is also my first ever PR, let me know if I'm doing something wrong_
